### PR TITLE
Removing extra blank spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = function(options) {
 
     return through.obj(function(file, encoding, callback) {
         var str = file.contents.toString();
+        str = str.replace(/\s+/g, ' ').trim();
 
         if (spacesToTabs) {
             var regex = new RegExp('^((?: {' + spacesToTabs + '})+)', 'gm');


### PR DESCRIPTION
For files with extra blank spaces, I propose to remove those spaces by replacing and trim the string before using the library parameters. This will help strings created as follow:
```
const myString = `
<div>hello world</div>
`
```